### PR TITLE
Replace ods-inputoptions with auro-checkbox

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@alaskaairux/auro-checkbox": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@alaskaairux/auro-checkbox/-/auro-checkbox-1.0.1.tgz",
-      "integrity": "sha512-EpuwSoatKinSCIZUG7XpgPR06+nKu1AXTCv5g7BdhW1ebvUW1VsEeC328uM3ExjMa0GQ9oQrHfIwR4BTfCs0UA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@alaskaairux/auro-checkbox/-/auro-checkbox-1.1.0.tgz",
+      "integrity": "sha512-O82PYxv9vtTWZS4c7JywcVxlm9tUSbmnZvtzzUX2Q4S2dNOT8kTpZBlTa4lQ7aVVOx2hGoHij0efFppRWpXMqw==",
       "dev": true,
       "requires": {
         "chalk": "^4.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,68 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@alaskaairux/auro-checkbox": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@alaskaairux/auro-checkbox/-/auro-checkbox-1.0.1.tgz",
+      "integrity": "sha512-EpuwSoatKinSCIZUG7XpgPR06+nKu1AXTCv5g7BdhW1ebvUW1VsEeC328uM3ExjMa0GQ9oQrHfIwR4BTfCs0UA==",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.1.0",
+        "lit-element": "^2.3.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "@alaskaairux/icons": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@alaskaairux/icons/-/icons-3.1.1.tgz",
@@ -67,13 +129,90 @@
       }
     },
     "@alaskaairux/ods-button": {
-      "version": "4.4.5",
-      "resolved": "https://registry.npmjs.org/@alaskaairux/ods-button/-/ods-button-4.4.5.tgz",
-      "integrity": "sha512-4QWYJhpl0cPbZC0WslBRE4UA6uxqf3f0+QrzWRT84IKOs/mWVbZgvAbUFE3mJL9vOBhfpaYzcu6JpzuP+lDP6A==",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@alaskaairux/ods-button/-/ods-button-4.6.1.tgz",
+      "integrity": "sha512-wYFYUtNKx5FoBAv+0n0ABkFf2k2GqMED9Z5dSz16HeezgXyfKvKH9waOIxkWdnWUDjS/4VLKlcflTUn9ah4ppA==",
       "dev": true,
       "requires": {
         "chalk": "^4.0.0",
         "lit-element": "^2.2.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "@alaskaairux/ods-toast": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@alaskaairux/ods-toast/-/ods-toast-1.1.2.tgz",
+      "integrity": "sha512-dAabHBzET6y2OgobNlw+S6JeWc6Zs5mL/KBG8i7KfGRlaQ7sgLNQPHavVToxvFlFBhSk832sLhb+aG/7XVzhUg==",
+      "dev": true,
+      "requires": {
+        "lit-element": "^2.1.0"
+      }
+    },
+    "@alaskaairux/orion-design-tokens": {
+      "version": "2.10.15",
+      "resolved": "https://registry.npmjs.org/@alaskaairux/orion-design-tokens/-/orion-design-tokens-2.10.15.tgz",
+      "integrity": "sha512-W9KIz4nGAn+8QxFAJ9cZsuayVyXgzIc2uZnDiYxZSyrpvpGp6X6i7UwxhF2Y7fXi5qLMK9aAY/oUC1C+KObN+A==",
+      "dev": true
+    },
+    "@alaskaairux/orion-icons": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@alaskaairux/orion-icons/-/orion-icons-2.1.5.tgz",
+      "integrity": "sha512-MsCues2ipQGOqHqmIK4zxNzCfbuGMAyCicJ1QaO1KyWSEX6GRHiDQCKw+wGgVvGAtmbRHzOqvhbFg7+RbWVMjg==",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.0.0",
+        "fs": "0.0.1-security"
       },
       "dependencies": {
         "ansi-styles": {
@@ -122,84 +261,6 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
           "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
           "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
-      }
-    },
-    "@alaskaairux/ods-inputoptions": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@alaskaairux/ods-inputoptions/-/ods-inputoptions-2.0.2.tgz",
-      "integrity": "sha512-RwejWiAf75EUapJrZvKx4ad24to7dGEg8UDtarJczXgDcuF9JlwKBS0oanRJ0PUgkLGcW/+drDVyBhVmkFQn3Q==",
-      "dev": true,
-      "requires": {
-        "lit-element": "^2.3.1"
-      }
-    },
-    "@alaskaairux/ods-toast": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@alaskaairux/ods-toast/-/ods-toast-1.1.2.tgz",
-      "integrity": "sha512-dAabHBzET6y2OgobNlw+S6JeWc6Zs5mL/KBG8i7KfGRlaQ7sgLNQPHavVToxvFlFBhSk832sLhb+aG/7XVzhUg==",
-      "requires": {
-        "lit-element": "^2.1.0"
-      }
-    },
-    "@alaskaairux/orion-design-tokens": {
-      "version": "2.10.15",
-      "resolved": "https://registry.npmjs.org/@alaskaairux/orion-design-tokens/-/orion-design-tokens-2.10.15.tgz",
-      "integrity": "sha512-W9KIz4nGAn+8QxFAJ9cZsuayVyXgzIc2uZnDiYxZSyrpvpGp6X6i7UwxhF2Y7fXi5qLMK9aAY/oUC1C+KObN+A==",
-      "dev": true
-    },
-    "@alaskaairux/orion-icons": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@alaskaairux/orion-icons/-/orion-icons-2.1.5.tgz",
-      "integrity": "sha512-MsCues2ipQGOqHqmIK4zxNzCfbuGMAyCicJ1QaO1KyWSEX6GRHiDQCKw+wGgVvGAtmbRHzOqvhbFg7+RbWVMjg==",
-      "requires": {
-        "chalk": "^4.0.0",
-        "fs": "0.0.1-security"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-          "requires": {
-            "@types/color-name": "^1.1.1",
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.0.0.tgz",
-          "integrity": "sha512-N9oWFcegS0sFr9oh1oz2d7Npos6vNoWW9HvtCg5N1KRFpUhaAhvTv5Y58g880fZaEYSNm3qDz8SU1UrGvp+n7A==",
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-        },
-        "supports-color": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
           "requires": {
             "has-flag": "^4.0.0"
           }
@@ -1286,7 +1347,8 @@
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
-      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
+      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
+      "dev": true
     },
     "@types/estree": {
       "version": "0.0.39",
@@ -2480,7 +2542,8 @@
     "fs": {
       "version": "0.0.1-security",
       "resolved": "https://registry.npmjs.org/fs/-/fs-0.0.1-security.tgz",
-      "integrity": "sha1-invTcYa23d84E/I4WLV+yq9eQdQ="
+      "integrity": "sha1-invTcYa23d84E/I4WLV+yq9eQdQ=",
+      "dev": true
     },
     "fs-extra": {
       "version": "8.1.0",
@@ -3160,6 +3223,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-2.3.1.tgz",
       "integrity": "sha512-tOcUAmeO3BzwiQ7FGWdsshNvC0HVHcTFYw/TLIImmKwXYoV0E7zCBASa8IJ7DiP4cen/Yoj454gS0qqTnIGsFA==",
+      "dev": true,
       "requires": {
         "lit-html": "^1.1.1"
       }
@@ -3167,7 +3231,8 @@
     "lit-html": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.2.1.tgz",
-      "integrity": "sha512-GSJHHXMGLZDzTRq59IUfL9FCdAlGfqNp/dEa7k7aBaaWD+JKaCjsAk9KYm2V12ItonVaYx2dprN66Zdm1AuBTQ=="
+      "integrity": "sha512-GSJHHXMGLZDzTRq59IUfL9FCdAlGfqNp/dEa7k7aBaaWD+JKaCjsAk9KYm2V12ItonVaYx2dprN66Zdm1AuBTQ==",
+      "dev": true
     },
     "livereload": {
       "version": "0.9.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start": "sirv public"
   },
   "devDependencies": {
-    "@alaskaairux/auro-checkbox": "^1.0.1",
+    "@alaskaairux/auro-checkbox": "^1.1.0",
     "@alaskaairux/icons": "^3.1.1",
     "@alaskaairux/ods-button": "^4.6.1",
     "@alaskaairux/ods-toast": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -7,10 +7,12 @@
     "start": "sirv public"
   },
   "devDependencies": {
+    "@alaskaairux/auro-checkbox": "^1.0.1",
     "@alaskaairux/icons": "^3.1.1",
-    "@alaskaairux/ods-button": "^4.4.5",
-    "@alaskaairux/ods-inputoptions": "^2.0.2",
+    "@alaskaairux/ods-button": "^4.6.1",
+    "@alaskaairux/ods-toast": "^1.1.2",
     "@alaskaairux/orion-design-tokens": "^2.10.15",
+    "@alaskaairux/orion-icons": "^2.1.5",
     "@alaskaairux/orion-web-core-style-sheets": "^2.9.3",
     "@babel/core": "^7.9.6",
     "@babel/plugin-syntax-dynamic-import": "^7.8.3",
@@ -33,8 +35,6 @@
     "svelte-preprocess": "^3.7.4"
   },
   "dependencies": {
-    "@alaskaairux/ods-toast": "^1.1.2",
-    "@alaskaairux/orion-icons": "^2.1.5",
     "sirv-cli": "^0.4.5"
   },
   "browserslist": [

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -55,13 +55,19 @@
 
 <main>
 	<h1 class="heading--display">Web Component Demo</h1>
-	<ods-inputoption-checkbox-group
-        label={`Your Choice: ${JSON.stringify(selectedOptions)}`}        
-        for="cbxDemo1">
+	<auro-checkbox-group required>
+		<span slot="legend">{`Your Choice: ${JSON.stringify(selectedOptions)}`}</span>
 		{#each options as option}
-		<ods-inputoption id={option.id} label={option.label} type="checkbox" value={option.value} checked={option.checked || undefined} on:input={handleInput}></ods-inputoption>
+		<auro-checkbox 
+			id={option.id} 
+			name="cbxDemo"
+			value={option.value} 
+			checked={option.checked || undefined} 
+			on:input={handleInput}>
+			{option.label}
+		</auro-checkbox>
 		{/each}
-	</ods-inputoption-checkbox-group>
+	</auro-checkbox-group>
 
     <auro-button on:click={toast} secondary={type === 'secondary' || undefined}>Toast</auro-button>
     <auro-button on:click={changeType}>Change Toaster</auro-button>

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -33,7 +33,7 @@
 		type = type === 'primary' ? 'secondary' : 'primary';
 	}
 
-	function handleInput(e) {
+	function handleChange(e) {
 		// Svelte won't let us bind to custom element groups
 		// So we have to keep track of the checkbox state ourselves, similar to a controlled component in React
 		const { target } = e;
@@ -63,7 +63,7 @@
 			name="cbxDemo"
 			value={option.value} 
 			checked={option.checked || undefined} 
-			on:input={handleInput}>
+			on:change={handleChange}>
 			{option.label}
 		</auro-checkbox>
 		{/each}

--- a/src/main.js
+++ b/src/main.js
@@ -14,7 +14,7 @@ if (window.WebComponents.ready) {
 
 async function loadWebComponents() {
 	await import('@alaskaairux/ods-button/dist/auro-button');
-	await import('@alaskaairux/ods-inputoptions/dist/ods-inputoption');
-	await import('@alaskaairux/ods-inputoptions/dist/ods-inputoption-checkbox-group');
+	await import('@alaskaairux/auro-checkbox');
+	await import('@alaskaairux/auro-checkbox/dist/auro-checkbox-group');
 	await import('@alaskaairux/ods-toast');
 }


### PR DESCRIPTION
This PR updates the Svelte demo to use auro-checkbox instead of ods-inputoptions v2. Existing demo functionality is preserved.